### PR TITLE
Update Module.php

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -150,7 +150,7 @@ class Module extends AbstractModule
         $roles = $acl->getRoles();
 
         $contributors = $isOpenContribution
-            ? null
+            ? array()
             : ($contributeRoles ?? $roles);
 
         $contributors = array_intersect($contributors, $acl->getRoles());


### PR DESCRIPTION
à la ligne 156, on fait un croisement de tableau, null n'est donc pas autorisé dans les valeurs de $contributors juste au dessus. la correction propose un tableau vide.

L'erreur se retrouve peut être ailleurs, je n'ai eu le message que pour la ligne 156.